### PR TITLE
Fixed prefix: typo

### DIFF
--- a/lib/koa-redis.js
+++ b/lib/koa-redis.js
@@ -38,7 +38,7 @@ var RedisStore = module.exports = function (options) {
   }
   EventEmitter.call(this);
   options = options || {};
-  this.prefix = options.prefix || 'koa:sass:';
+  this.prefix = options.prefix || 'koa:sess:';
   var client;
 
   if (!options.client) {


### PR DESCRIPTION
session prefix should default to 'koa:sess:' was defaulting to 'koas:sass:'
