### PR TITLE
Fix Test & Coverage (Travis)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,18 @@
 language: node_js
 node_js:
-  - '0.12'
-  - "iojs-v1"
-  - "iojs-v2"
-  - "iojs-v3"
+  - "4"
+  - "5"
+sudo: false
 script: make test-coveralls
 install:
-  - 'make install'
+  - make install
 services:
   - redis-server
+env:
+  - CXX=g++-4.8
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-4.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ node_js:
   - "4"
   - "5"
 sudo: false
-install: npm install
-script: make test-coveralls
+script: make test-travis
+after_script: npm install coveralls && cat ./coverage/lcov.info | coveralls
 services:
   - redis-server
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,8 @@ node_js:
   - "4"
   - "5"
 sudo: false
+install: npm install
 script: make test-coveralls
-install:
-  - make install
 services:
   - redis-server
 env:

--- a/Makefile
+++ b/Makefile
@@ -6,34 +6,39 @@ MOCHA_OPTS =
 install:
 	npm install
 
-test: install
+test:
 	NODE_ENV=test ./node_modules/mocha/bin/mocha \
-		--harmony \
+		--harmony\
 		--reporter $(REPORTER) \
 		--timeout $(TIMEOUT) \
 		--require should \
 		$(MOCHA_OPTS) \
 		$(TESTS)
 
+
 test-cov:
-	$(MAKE) test MOCHA_OPTS='--require blanket' REPORTER=travis-cov
+	NODE_ENV=test node --harmony \
+		node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha \
+		-- -u exports \
+		--reporter $(REPORTER) \
+		--timeout $(TIMEOUT) \
+		--require should \
+		$(MOCHA_OPTS) \
+		$(TESTS)
 
-test-cov-html:
-	rm -f coverage.html
-	$(MAKE) test MOCHA_OPTS='--require blanket' REPORTER=html-cov > coverage.html
-	ls -lh coverage.html
+test-travis:
+	NODE_ENV=test node --harmony \
+		node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha \
+		--report lcovonly \
+		-- -u exports \
+		--reporter $(REPORTER) \
+		--timeout $(TIMEOUT) \
+		--require should \
+		$(MOCHA_OPTS) \
+		$(TESTS)
 
-test-coveralls: test
-	@echo TRAVIS_JOB_ID $(TRAVIS_JOB_ID)
-	$(MAKE) test MOCHA_OPTS='--require blanket' REPORTER=mocha-lcov-reporter | ./node_modules/coveralls/bin/coveralls.js
-
-test-all: test test-cov
-
-contributors: install
-	@./node_modules/contributors/bin/contributors -f plain -o AUTHORS
-
-autod: install
-	./node_modules/.bin/autod -w -e example.js,benchmark --prefix='~'
+autod:
+	./node_modules/.bin/autod -w -e example --prefix=~ --keep=supertest,debug, --semver=koa@1
 	$(MAKE) install
 
 .PHONY: test

--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,10 @@ TIMEOUT = 5000
 MOCHA_OPTS =
 
 install:
-	@npm install
+	npm install
 
 test: install
-	@NODE_ENV=test ./node_modules/mocha/bin/mocha \
+	NODE_ENV=test ./node_modules/mocha/bin/mocha \
 		--harmony \
 		--reporter $(REPORTER) \
 		--timeout $(TIMEOUT) \
@@ -16,16 +16,16 @@ test: install
 		$(TESTS)
 
 test-cov:
-	@$(MAKE) test MOCHA_OPTS='--require blanket' REPORTER=travis-cov
+	$(MAKE) test MOCHA_OPTS='--require blanket' REPORTER=travis-cov
 
 test-cov-html:
-	@rm -f coverage.html
-	@$(MAKE) test MOCHA_OPTS='--require blanket' REPORTER=html-cov > coverage.html
-	@ls -lh coverage.html
+	rm -f coverage.html
+	$(MAKE) test MOCHA_OPTS='--require blanket' REPORTER=html-cov > coverage.html
+	ls -lh coverage.html
 
 test-coveralls: test
 	@echo TRAVIS_JOB_ID $(TRAVIS_JOB_ID)
-	@-$(MAKE) test MOCHA_OPTS='--require blanket' REPORTER=mocha-lcov-reporter | ./node_modules/coveralls/bin/coveralls.js
+	$(MAKE) test MOCHA_OPTS='--require blanket' REPORTER=mocha-lcov-reporter | ./node_modules/coveralls/bin/coveralls.js
 
 test-all: test test-cov
 
@@ -33,7 +33,7 @@ contributors: install
 	@./node_modules/contributors/bin/contributors -f plain -o AUTHORS
 
 autod: install
-	@./node_modules/.bin/autod -w -e example.js,benchmark --prefix='~'
-	@$(MAKE) install
+	./node_modules/.bin/autod -w -e example.js,benchmark --prefix='~'
+	$(MAKE) install
 
 .PHONY: test

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ TIMEOUT = 5000
 MOCHA_OPTS =
 
 install:
-	@npm install --registry=http://registry.npm.taobao.org
+	@npm install
 
 test: install
 	@NODE_ENV=test ./node_modules/mocha/bin/mocha \

--- a/package.json
+++ b/package.json
@@ -15,15 +15,12 @@
     "autod": "~0.2.0",
     "blanket": "*",
     "co": "~3.0.6",
-    "contributors": "*",
-    "coveralls": "*",
-    "koa": "~0.13.0",
-    "koa-generic-session": "~1.0.0",
+    "istanbul": "*",
+    "koa": "~1.1.2",
+    "koa-generic-session": "~1.10.0",
     "mocha": "*",
-    "mocha-lcov-reporter": "*",
     "should": "~4.0.4",
-    "supertest": "0.8.2",
-    "travis-cov": "*"
+    "supertest": "0.8.2"
   },
   "engines": {
     "node": ">= 0.11.9"


### PR DESCRIPTION
I didn't modify the actual tests. I simply fixed Travis to run them and report the coverage. I modeled off of [koajs/generic-session](https://github.com/koajs/generic-session):
 - Updated NodeJS versions to tests with
 - Updated to faster, new Travis container
 - Removed `npm install` from tests (Travis does automatically, external registry causing timeout)
 - Make coverage posting separate from actual tests (and added Istanbul)