### PR TITLE
Support optional serialize and unserialize

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ For more examples, please see the [examples folder of `koa-generic-session`](htt
  - `db` (number) - will run `client.select(db)` after connection
  - `client` (object) - supply your own client, all other options are ignored unless `duplicate` is also supplied
  - `duplicate` (boolean) - When true, it will run `client.duplicate(options)` on the supplied `client` and use all other options supplied. This is useful if you want to select a different DB for sessions but also want to base from the same client object.
+ - `serialize` - Used to serialize the data that is saved into the store.
+ - `unserialize` - Used to unserialize the data that is fetched from the store.
  - **DEPRECATED:** old options - `pass` and `socket` have been replaced by `auth_pass` and `path`, but they should be backwards compatible (still work).
 
 ### Events

--- a/index.js
+++ b/index.js
@@ -110,8 +110,8 @@ var RedisStore = module.exports = function (options) {
   this.connected = client.connected;
 
   // support optional serialize and unserialize
-  this.serialize = options.serialize || JSON.stringify;
-  this.unserialize = options.unserialize || JSON.parse;
+  this.serialize = (typeof options.serialize === 'function' && options.serialize) || JSON.stringify;
+  this.unserialize = (typeof options.unserialize === 'function' && options.unserialize) || JSON.parse;
 };
 
 util.inherits(RedisStore, EventEmitter);

--- a/test/koa-redis.test.js
+++ b/test/koa-redis.test.js
@@ -76,6 +76,23 @@ describe('test/koa-redis.test.js', function () {
     yield store.quit();
   });
 
+  it('should use default JSON.parse/JSON.stringify without serialize/unserialize function', function* () {
+    var store = require('../')({serialize: 'Not a function', 'unserialize': 'Not a function'});
+    yield store.set('key:notserialized', {a: 1});
+    (yield store.get('key:notserialized')).should.eql({a: 1});
+    yield store.quit();
+  });
+
+  it('should parse bad JSON with custom unserialize function', function* () {
+    var store = require('../')({
+      serialize: (value) => ('JSON:' + JSON.stringify(value)), 
+      'unserialize': (value) => JSON.parse(value.slice(5))
+    });
+    yield store.set('key:notserialized', {a: 1});
+    (yield store.get('key:notserialized')).should.eql({a: 1});
+    yield store.quit();
+  });
+
   it('should set without ttl ok', function* () {
     var store = require('../')();
     yield store.set('key:nottl', {a: 1});


### PR DESCRIPTION
When I am restructuring some existing code that wrote by Java and PHP, I have a problem. Data in store was serialize or unserialize in Java/PHP Object serialization, so I want to make this repo support serialize/unserialize.

Please review it.