### PR TITLE
Allow url option that's forwarded to ioredis

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -42,11 +42,15 @@ function RedisStore(options) {
   options.password =
     options.password || options.auth_pass || options.pass || null; // For backwards compatibility
   options.path = options.path || options.socket || null; // For backwards compatibility
+
   if (!options.client) {
     //
     // TODO: we should probably omit custom options we have
     // in this lib from `options` passed to instances below
     //
+    const redisUrl = options.url && options.url.toString();
+    delete options.url;
+
     if (options.isRedisCluster) {
       debug('Initializing Redis Cluster');
       delete options.isRedisCluster;
@@ -56,7 +60,7 @@ function RedisStore(options) {
       delete options.isRedisCluster;
       delete options.nodes;
       delete options.clusterOptions;
-      client = new Redis(options);
+      client = redisUrl ? new Redis(redisUrl, options) : new Redis(options);
     }
   } else if (options.duplicate) {
     // Duplicate client and update with options provided

--- a/test/koa-redis.test.js
+++ b/test/koa-redis.test.js
@@ -45,6 +45,18 @@ describe('test/koa-redis.test.js', () => {
     store.connected.should.eql(false);
   });
 
+  it('should connect and ready with url and quit ok', function*() {
+    const store = require('..')({
+      url: 'redis://localhost:6379/'
+    });
+    yield event(store, 'connect');
+    store.connected.should.eql(true);
+    yield event(store, 'ready');
+    yield store.quit();
+    yield event(store, 'end');
+    store.connected.should.eql(false);
+  });
+
   it('should set and delete with db ok', function*() {
     const store = require('..')({ db: 2 });
     const client = new Redis();


### PR DESCRIPTION
Fix for https://github.com/koajs/koa-redis/issues/64 and allows passing a url in the options for koa-redis (`url` was not a valid option in v4.0.0, though it's [mentioned in the readme still](https://github.com/koajs/koa-redis#options)). This change also makes it backwards compatible with 3.

If present, this is passed to ioredis as the first argument, with the other options as the second argument [see here for details](https://github.com/luin/ioredis/blob/master/API.md#new-redisport-host-options)
> new Redis([port], [host], [options])

> [port] - Port of the Redis server, or a URL string(see the examples below), or the options object(see the third argument).

> [host] - Host of the Redis server, when the first argument is a URL string, this argument is an object represents the options.

This allows ioredis to parse the url string instead of forcing you to pass each parameter separately.

As an example:
```
redisStore({
  url: 'redis://user:password@redis-service.com:6379/'
})
```

would be the equivalent of `new Redis('redis://user:password@redis-service.com:6379/');` in ioredis